### PR TITLE
Update wyoming-onnx-asr to 0.5.0

### DIFF
--- a/onnx-asr/DOCS.md
+++ b/onnx-asr/DOCS.md
@@ -46,6 +46,7 @@ Available models, english only:
 - `nemo-parakeet-tdt-0.6b-v2`
 - `nemo-parakeet-rnnt-0.6b`
 - `nemo-parakeet-ctc-0.6b`
+- `nemo-canary-1b-v2`
 - `onnx-community/whisper-base.en`
 - `onnx-community/whisper-tiny.en`
 - `onnx-community/whisper-small.en`
@@ -61,6 +62,7 @@ Available models:
 
 - `auto` (select author's most efficient model)
 - `nemo-parakeet-tdt-0.6b-v3`
+- `nemo-canary-1b-v2`
 - `whisper-base`
 - `onnx-community/whisper-tiny`
 - `onnx-community/whisper-base`

--- a/onnx-asr/Dockerfile
+++ b/onnx-asr/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install ONNX ASR
 WORKDIR /usr/src
-ARG WYOMING_ONNX_ASR_VERSION="0.4.1"
+ARG WYOMING_ONNX_ASR_VERSION="0.5.0"
 
 RUN \
     apt-get update \


### PR DESCRIPTION
This just update wyoming-onnx-asr to 0.5.0, which in turn updates onnx-asr to 0.10.1. This adds support for canary-1b-v2, although it appears to be worse than parakeet-v3.